### PR TITLE
Add and fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ xBOUT examples
 ==============
 
 A set of self-contained examples showing various features of
-[xBOUT](github.com/boutproject/xBOUT).
+[xBOUT](https://github.com/boutproject/xBOUT).
 
 Getting started
 ---------------
@@ -12,8 +12,8 @@ The quickest way to get started is to run the notebook in your browser, on
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/boutproject/xBOUT-examples/master)
 
 Alternatively, to run these examples on your own machine, you will require
-xBOUT and Jupyter.  You can install these and all their requirements using
-conda (after setting up
+xBOUT and [Jupyter](https://jupyter.org/). You can install these and all
+their requirements using conda (after setting up
 [anaconda](https://www.anaconda.com/) or
 [miniconda](https://docs.conda.io/en/latest/miniconda.html)) by running
 ```
@@ -31,13 +31,14 @@ size. Clone with
 $ git clone --depth 1 https://github.com/boutproject/xBOUT-examples.git
 ```
 
-Finally, navigate into the xBOUT-examples directory and run
+Finally, navigate into the `xBOUT-examples/` directory and run
 ```
 $ jupyter notebook
 ```
 A Jupyter session will open in a web browser.  Click on the subdirectory for
 the example you are interested in, and then click on the Jupyter notebook (file
-ending `.ipynb`) to open the example (if you are new to xarray and xBOUT, we
+ending `.ipynb`) to open the example (if you are new to
+[xarray](http://xarray.pydata.org/en/stable/) and xBOUT, we
 suggest starting with 'tutorial'), and follow the instructions there.
 
 Contributor guidelines
@@ -46,7 +47,8 @@ Contributor guidelines
 In order to make the examples easy to use, we keep them in a single repo and do
 not use git-lfs. That means we need to stop the repo from getting too big. We
 also want the examples to be self-contained, so people do not need to have
-BOUT++ set up and running before they can run these examples.
+[BOUT++](https://boutproject.github.io/) set up and running before they can
+run these examples.
 
 Some guidelines for making examples:
 
@@ -54,14 +56,14 @@ Some guidelines for making examples:
   and linked from the example.
 
 * Even if the code is available, the dataset needed for each example should be
-  archived on [Zenodo](zenodo.org) so that the example can be run
+  archived on [Zenodo](https://zenodo.org) so that the example can be run
   independently.
 
     * Please provide a setup call to download the data from Zenodo if it is not
       present.
 
     * Add a line or lines to the `postBuild` file to download your data for
-      [binder.org](binder.org).
+      [binder.org](https://binder.org).
 
 * We will use squash-merging of pull requests to minimise the number of data
   objects (e.g. plot output in Jupyter notebooks) present in the history.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Some guidelines for making examples:
       present.
 
     * Add a line or lines to the `postBuild` file to download your data for
-      [binder.org](https://binder.org).
+      [mybinder.org](https://mybinder.org).
 
 * We will use squash-merging of pull requests to minimise the number of data
   objects (e.g. plot output in Jupyter notebooks) present in the history.


### PR DESCRIPTION
There were a couple of links in `README.md` which weren't working since they were missing the beginning `https://`.  This PR fixes the links, and also adds a few more links to xarray, BOUT++, etc.