### PR TITLE
Use `%matplotlib widget` notebook to support JupyterLab

### DIFF
--- a/.github/workflows/testexamples.yml
+++ b/.github/workflows/testexamples.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get update && sudo apt-get install libhdf5-dev libnetcdf-dev
         python -m pip install --upgrade pip
-        pip install --upgrade jupyter
+        pip install --upgrade jupyter ipympl
     - name: Install xbout release
       if: ${{matrix.xbout-version == 'release'}}
       run: |

--- a/blob2d/blob2d_example.ipynb
+++ b/blob2d/blob2d_example.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# set up matplotlib\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "from matplotlib import pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (16, 8)\n",
     "plt.rcParams.update({\"font.size\": 14})"

--- a/hasegawa-wakatani/hasegawa-wakatani_example.ipynb
+++ b/hasegawa-wakatani/hasegawa-wakatani_example.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "# set up matplotlib\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "from matplotlib import pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (16, 8)\n",
     "plt.rcParams.update({\"font.size\": 14})"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 xbout>=0.3.4
+ipympl
+jupyter

--- a/tutorial/tutorial.ipynb
+++ b/tutorial/tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "plt.rcParams[\"figure.figsize\"] = (16, 8)\n",
     "plt.rcParams.update({\"font.size\": 14})"


### PR DESCRIPTION
Apparently JupyterLab does not support matplotlib plots when using `%matplotlib notebook`. mybinder.org uses JupyterLab by default, so we want to support it.